### PR TITLE
Minor modifications to simplify usage

### DIFF
--- a/icepaposc/__main__.py
+++ b/icepaposc/__main__.py
@@ -45,6 +45,8 @@ def get_parser():
                        help='IcePAP port')
     parse.add_argument('-t', '--timeout', type=int, default=3,
                        help='Socket timeout')
+    parse.add_argument('--sigset', default='',
+                       help='.lst filename to import signals from')
     parse.add_argument('-s', '--sig', nargs='*', default=[],
                        help='Preselected signals '
                             '<driver>:<signal name>:<Y-axis>')
@@ -60,9 +62,10 @@ def get_parser():
 
 def main():
     args = get_parser().parse_args()
+    print(args)
 
     app = QApplication(sys.argv)
-    win = WindowMain(args.host, args.port, args.timeout, args.sig, args.axis)
+    win = WindowMain(args.host, args.port, args.timeout, args.sig, args.axis, args.sigset)
     win.show()
     sys.exit(app.exec_())
 

--- a/icepaposc/curve_item.py
+++ b/icepaposc/curve_item.py
@@ -58,6 +58,8 @@ class CurveItem:
         self.update_signature()
         if sig_name.upper().startswith("POS"): 
             self.signal_type = 1
+        elif sig_name.upper().startswith("DIF"):
+            self.signal_type = 3
         elif sig_name.upper().startswith("ENC"):
             self.signal_type = 2
         elif sig_name.upper().startswith("VEL"):

--- a/icepaposc/ui/window_main.ui
+++ b/icepaposc/ui/window_main.ui
@@ -197,7 +197,7 @@
                 <number>1</number>
                </property>
                <property name="maximum">
-                <number>3</number>
+                <number>4</number>
                </property>
               </widget>
              </item>
@@ -1495,6 +1495,11 @@
           <item>
            <property name="text">
             <string>Y3</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Y4</string>
            </property>
           </item>
           <item>


### PR DESCRIPTION
List of features added/fixed:
- '-s' option, i.e.: specifying curves from the command line, now works
- '--sigset' option, adding a file with a list of curves from the command line added
- Correction factors to the pos/vel/diff/enc curves modified so that they apply to all the acquired data and not only to the newly acquired data (that was forcing to retest if any check with correction was required)
- CTRL-U allows to switch between correction factors in the ui and no correction factors applied.
- CTRL-O saves the data in the time range currently displayed to a .csv file
- A double click at an time coordinate fixes a crosshair there allowing to measure differences in the curves with that time position. A single right click clears the fixed crosshair.
- The double-click + click sequence above defines a local time range to calculate the maximum and minimum of the curves shown at the top of the display area. A third click resets the range to the whole capture data set. 
- Added some code to allow for some more flexibility with the Y-axes. Now axes not used are removed from the display area.