### PR TITLE
Future version 0.10.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = True
 tag_name = {new_version}
-current_version = 0.10.0
+current_version = 0.10.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = True
 tag_name = {new_version}
-current_version = 0.10.2
+current_version = 0.10.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = True
 tag_name = {new_version}
-current_version = 0.10.1
+current_version = 0.10.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = True
 tag_name = {new_version}
-current_version = 0.10.3
+current_version = 0.10.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Autorangey/autorange_y_tiled(split viewbox vertically)
 - Other minor fixes
 - Ysplitview feature modification to use up space better vertically
+- Fix long description
 
 ## [0.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  all y axes' and 'divide vertical space between yaxes and setRange 
  accordingly' (try yourself).
  - The hotkeys are now available via icepaposc -h
+ - Add Encmeasure method 
  
 
 ### Removed
@@ -25,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Other minor fixes
 - Ysplitview feature modification to use up space better vertically
 - Fix long description
-
+- Use pos instead of fpos to read posmeasure, difaxmeasure
 ## [0.9.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Autorangex/autopanx switch
 - Autorangey/autorange_y_tiled(split viewbox vertically)
 - Other minor fixes
+- Ysplitview feature modification to use up space better vertically
 
 ## [0.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Fixed signal sets from command line and dialog
+- Hotkeys arranged to match ipaptrend. See –help
+- Autorangex/autopanx switch
+- Autorangey/autorange_y_tiled(split viewbox vertically)
+- Other minor fixes
 
 ## [0.9.0]
 
@@ -158,5 +163,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.6.4]: https://github.com/ALBA-Synchrotron/IcepapOCS/compare/0.5.2...0.6.4
 [0.7.1]: https://github.com/ALBA-Synchrotron/IcepapOCS/compare/0.6.4...0.7.1
 [0.8.2]: https://github.com/ALBA-Synchrotron/IcepapOCS/compare/0.7.1...0.8.2
-[0.9.x]: https://github.com/ALBA-Synchrotron/IcepapOCS/compare/0.8.2...HEAD
+[0.9.0]: https://github.com/ALBA-Synchrotron/IcepapOCS/compare/0.8.2...0.9.0
+[0.10.x]: https://github.com/ALBA-Synchrotron/IcepapOCS/compare/0.9.0...HEAD
 

--- a/icepaposc/__init__.py
+++ b/icepaposc/__init__.py
@@ -19,4 +19,4 @@
 
 # The version is updated automatically with bumpversion
 # Do not update manually
-version = '0.10.2'
+version = '0.10.3'

--- a/icepaposc/__init__.py
+++ b/icepaposc/__init__.py
@@ -19,4 +19,4 @@
 
 # The version is updated automatically with bumpversion
 # Do not update manually
-version = '0.10.0'
+version = '0.10.1'

--- a/icepaposc/__init__.py
+++ b/icepaposc/__init__.py
@@ -19,4 +19,4 @@
 
 # The version is updated automatically with bumpversion
 # Do not update manually
-version = '0.10.1'
+version = '0.10.2'

--- a/icepaposc/__init__.py
+++ b/icepaposc/__init__.py
@@ -19,4 +19,4 @@
 
 # The version is updated automatically with bumpversion
 # Do not update manually
-version = '0.10.3'
+version = '0.10.4'

--- a/icepaposc/__main__.py
+++ b/icepaposc/__main__.py
@@ -25,49 +25,71 @@ from . import version
 
 
 def get_parser():
-    desc = 'IcePAP Oscilloscope Application, base on ethernet communication\n'
-    desc += 'Version: {}.\n'.format(version)
-    desc += '\n'
-    desc += 'Hotkeys:\n'
-    desc += 'Ctrl+O: Save VISIBLE contents to csv format file\n'
-    desc += 'Ctrl+U: Toggle correction factors on and off\n'
-    desc += 'Ctrl+I: Input dialog for csv file name\n'
-    desc += 'Ctrl+Y: Enable autorange on Ys\n'
-    desc += 'Ctrl+R: Zoom IN time axis\n'
-    desc += 'Ctrl+E: Zoom OUT time axis\n'
-    desc += 'Ctrl+T: Toggle autorange X/autopan X\n'
-    desc += '\n'
-    desc += 'Import/export format:\n'
-    desc += 'Signal yrange(1-6) color driver_addr_OR_x_for_selected forceautorange 1blackbackground\n'
-    epi = 'Documentation: https://alba-synchrotron.github.io/pyIcePAP-doc/\n'
-    epi += 'Copyright 2017:\n' \
-           '   MAX IV Laboratory, Lund, Sweden\n' \
-           '   CELLS / ALBA Synchrotron, Bellaterra, Spain.'
+    desc = "IcePAP Oscilloscope Application, base on ethernet communication\n"
+    desc += "Version: {}.\n".format(version)
+    desc += "\n"
+    desc += "Hotkeys:\n"
+    desc += "Ctrl+O: Save VISIBLE contents to csv format file\n"
+    desc += "Ctrl+U: Toggle correction factors on and off\n"
+    desc += "Ctrl+I: Input dialog for csv file name\n"
+    desc += "Ctrl+Y: Enable autorange on Ys\n"
+    desc += "Ctrl+R: Zoom IN time axis\n"
+    desc += "Ctrl+E: Zoom OUT time axis\n"
+    desc += "Ctrl+T: Toggle autorange X/autopan X\n"
+    desc += "\n"
+    desc += "Import/export format:\n"
+    desc += "Signal yrange(1-6) color driver_addr_OR_x_for_selected forceautorange 1blackbackground\n"
+    epi = "Documentation: https://alba-synchrotron.github.io/pyIcePAP-doc/\n"
+    epi += (
+        "Copyright 2017:\n"
+        "   MAX IV Laboratory, Lund, Sweden\n"
+        "   CELLS / ALBA Synchrotron, Bellaterra, Spain."
+    )
     fmt = argparse.RawTextHelpFormatter
-    parse = argparse.ArgumentParser(description=desc,
-                                    formatter_class=fmt,
-                                    epilog=epi)
-    ver = '%(prog)s {0}'.format(version)
+    parse = argparse.ArgumentParser(description=desc, formatter_class=fmt, epilog=epi)
+    ver = "%(prog)s {0}".format(version)
 
-    parse.add_argument('--version', action='version', version=ver)
+    parse.add_argument("--version", action="version", version=ver)
 
-    parse.add_argument('host', help='IcePAP Host')
-    parse.add_argument('--axis', help='Selected axis', default=1, type=int)
-    parse.add_argument('-p', '--port', type=int, default=5000,
-                       help='IcePAP port')
-    parse.add_argument('-t', '--timeout', type=int, default=3,
-                       help='Socket timeout')
-    parse.add_argument('--sigset', default='',
-                       help='.lst filename to import signals from')
-    parse.add_argument('--corr', default='',
-                       help='Default curves correction factors'
-                            '--corr=\'pa,pb,ea,eb\'')
-    parse.add_argument('--yrange', default='',
-                       help='Default yaxes with skipped autorange when '
-                            'slotted yview --yrange=\'1,3,5\'')
-    parse.add_argument('-s', '--sig', nargs='*', default=[],
-                       help='Preselected signals '
-                            '<driver>:<signal name>:<Y-axis>')
+    parse.add_argument("host", help="IcePAP Host")
+    parse.add_argument("--axis", help="Selected axis", default=1, type=int)
+    parse.add_argument("-p", "--port", type=int, default=5000, help="IcePAP port")
+    parse.add_argument("-t", "--timeout", type=int, default=3, help="Socket timeout")
+    parse.add_argument(
+        "--sigset", default="", help=".lst filename to import signals from"
+    )
+    parse.add_argument(
+        "--corr",
+        default="",
+        help="Default curves correction factors" "--corr='pa,pb,ea,eb'",
+    )
+    parse.add_argument(
+        "--yrange",
+        default="",
+        help="Default yaxes with skipped autorange when "
+        "slotted yview --yrange='1,3,5'",
+    )
+    parse.add_argument(
+        "-dr",
+        "--dump_rate",
+        type=int,
+        default=10,
+        help="Number of samples acquired before update ui",
+    )
+    parse.add_argument(
+        "-sr",
+        "--sample_rate",
+        type=int,
+        default=10,
+        help="Number of ms between samples (best effort)",
+    )
+    parse.add_argument(
+        "-s",
+        "--sig",
+        nargs="*",
+        default=[],
+        help="Preselected signals " "<driver>:<signal name>:<Y-axis>",
+    )
 
     # TODO: Allow to pass the axes preselected and type of graph
     # parse.add_argument('-a', nargs='*', help='Axes to save, default all',
@@ -83,8 +105,18 @@ def main():
     print(args)
 
     app = QApplication(sys.argv)
-    win = WindowMain(args.host, args.port, args.timeout, args.sig,
-                     args.axis, args.sigset, args.corr, args.yrange)
+    win = WindowMain(
+        args.host,
+        args.port,
+        args.timeout,
+        args.sig,
+        args.axis,
+        args.sigset,
+        args.corr,
+        args.yrange,
+        args.dump_rate,
+        args.sample_rate,
+    )
     win.show()
     sys.exit(app.exec_())
 

--- a/icepaposc/__main__.py
+++ b/icepaposc/__main__.py
@@ -63,7 +63,7 @@ def get_parser():
                        help='Default curves correction factors'
                             '--corr=\'pa,pb,ea,eb\'')
     parse.add_argument('--yrange', default='',
-                       help='Default yaxes with forced autorange when '
+                       help='Default yaxes with skipped autorange when '
                             'slotted yview --yrange=\'1,3,5\'')
     parse.add_argument('-s', '--sig', nargs='*', default=[],
                        help='Preselected signals '

--- a/icepaposc/collector.py
+++ b/icepaposc/collector.py
@@ -20,28 +20,13 @@
 from PyQt5 import QtCore
 from collections import OrderedDict
 from icepap import IcePAPController
+# from .tests.FIcePAPController import FIcePAPController as IcePAPController
 from .channel import Channel
 import time
 
 
-class Collector:
-    """Feeds a subscriber with collected IcePAP signal data."""
-
-    def __init__(self, host, port, timeout, settings, callback):
-        """
-        Initializes an instance of class Collector.
-
-        host     - The IcePAP system host name.
-        port     - The IcePAP system port number.
-        timeout  - Socket timeout.
-        callback - A callback function used for sending collected signal
-                   data back to the caller.
-                   cb_func(subscription_id, value_list)
-                       subscription_id - The subscription id retained when
-                                         subscribing for a signal.
-                       value_list      - A list of tuples
-                                         (time_stamp, signal_value)
-        """
+class IcePAPDescriptor:
+    def __init__(self, host, port, timeout):
         self.sig_getters = OrderedDict(
             [('PosAxis', self._getter_pos_axis),
              ('PosTgtenc', self._getter_pos_tgtenc),
@@ -80,20 +65,10 @@ class Collector:
         )
         self.host = host
         self.port = port
-        self.settings = settings
-        self.cb = callback
-        self.icepap_system = None
-        self.channels_subscribed = {}
-        self.channels = {}
-        self.channel_id = 0
-        self.current_channel = 0
-        # affine corrections for POS and ENC signals (to show them in different
-        # units)
-        self.poscorr_a = 1
+        self.poscorr_a = 1 # These can be cleaned up. Done elsewhere
         self.poscorr_b = 0
         self.enccorr_a = 1
         self.enccorr_b = 0
-        self.sig_list = list(self.sig_getters.keys())
 
         try:
             self.icepap_system = IcePAPController(self.host, self.port,
@@ -102,14 +77,8 @@ class Collector:
             msg = 'Failed to instantiate master controller.\nHost: ' \
                   '{}\nPort: {}\n{}'.format(self.host, self.port, e)
             raise Exception(msg)
-        if not self.icepap_system:
-            msg = 'IcePAP system {} has no active drivers! ' \
-                  'Aborting.'.format(self.host)
-            raise Exception(msg)
-
-        self.ticker = QtCore.QTimer()
-        self.ticker.timeout.connect(self._tick)
-        self.ticker.start(self.settings.sample_rate)
+        
+        self.sig_list = list(self.sig_getters.keys())
 
     def get_available_drivers(self):
         """
@@ -134,31 +103,14 @@ class Collector:
         Return: Signal index.
         """
         return self.sig_list.index(signal_name)
+    
+    def get_getters(self):
+        return list(self.sig_getters.keys())
 
-    @staticmethod
-    def get_current_time():
-        """
-        Retrieves the current time.
-
-        Return: Current time as seconds (with fractions) from 1970.
-        """
-        return time.time()
-
-    def subscribe(self, icepap_addr, signal_name):
-        """
-        Creates a new subscription for signal values.
-
-        icepap_addr - IcePAP driver number.
-        signal_name - Signal name.
-        Return - A positive integer id used when unsubscribing.
-        """
-        for ch in list(self.channels_subscribed.values()):
-            if ch.equals(icepap_addr, signal_name):
-                msg = 'Channel already exists.\nAddr: ' \
-                      '{}\nSignal: {}'.format(icepap_addr, signal_name)
-                raise Exception(msg)
-        channel = Channel(icepap_addr, signal_name)
-        sn = str(signal_name)
+    def get_sig_getters(self):
+        return self.sig_getters
+    
+    def subscription_checks(self, icepap_addr, sn, channel):
         cond_1 = sn.endswith('Tgtenc')
         cond_2 = sn.endswith('Shftenc')
         cond_3 = sn == 'DifAxMeasure'
@@ -175,48 +127,6 @@ class Collector:
                 raise Exception(msg)
             if cond_3:
                 channel.set_measure_resolution(cfg)
-        self.channel_id += 1
-        self.channels_subscribed[self.channel_id] = channel
-        return self.channel_id
-
-    def start(self, subscription_id):
-        """
-        Starts collecting data for a subscription.
-
-        subscription_id - The given subscription id.
-        """
-        if subscription_id in list(self.channels_subscribed.keys()) and \
-                subscription_id not in list(self.channels.keys()):
-            self.channels[subscription_id] = \
-                self.channels_subscribed[subscription_id]
-
-    def unsubscribe(self, subscription_id):
-        """
-        Cancels a subscription.
-
-        subscription_id - The given subscription id.
-        """
-        if subscription_id in list(self.channels_subscribed.keys()):
-            del self.channels[subscription_id]
-            del self.channels_subscribed[subscription_id]
-
-    def _tick(self):
-        for subscription_id, channel in self.channels.items():
-            self.current_channel = subscription_id
-            try:
-                addr = channel.icepap_address
-                val = self.sig_getters[channel.sig_name](addr)
-            except RuntimeError as e:
-                msg = 'Failed to collect data for signal ' \
-                      '{}\n{}'.format(channel.sig_name, e)
-                print(msg)
-                continue
-            tv = (time.time(), val)
-            channel.collected_samples.append(tv)
-            if len(channel.collected_samples) >= self.settings.dump_rate:
-                self.cb(subscription_id, channel.collected_samples)
-                channel.collected_samples = []
-        self.ticker.start(self.settings.sample_rate)
 
     def _getter_pos_axis(self, addr):
         x = self.icepap_system[addr].pos
@@ -364,3 +274,158 @@ class Collector:
         x = self.icepap_system[addr].get_velocity(vtype='MOTOR')
         x = x * self.poscorr_a
         return x
+
+class Collector:
+    """Feeds a subscriber with collected IcePAP signal data."""
+
+    def __init__(self, host, port, timeout, settings, callback):
+        """
+        Initializes an instance of class Collector.
+
+        host     - The IcePAP system host name.
+        port     - The IcePAP system port number.
+        timeout  - Socket timeout.
+        callback - A callback function used for sending collected signal
+                   data back to the caller.
+                   cb_func(subscription_id, value_list)
+                       subscription_id - The subscription id retained when
+                                         subscribing for a signal.
+                       value_list      - A list of tuples
+                                         (time_stamp, signal_value)
+        """
+        self.settings = settings
+        self.cb = callback
+        self.icepap_system = None
+        self.channels_subscribed = {}
+        self.channels = {}
+        self.channel_id = 0
+        self.current_channel = 0
+        # affine corrections for POS and ENC signals (to show them in different
+        # units)
+        self.host = host
+        self.port = port
+
+        '''
+        try:
+            self.icepap_system = IcePAPController(self.host, self.port,
+                                                  timeout, auto_axes=True)
+        except Exception as e:
+            msg = 'Failed to instantiate master controller.\nHost: ' \
+                  '{}\nPort: {}\n{}'.format(self.host, self.port, e)
+            raise Exception(msg)
+        '''
+        try:
+            self.icepap_system = IcePAPDescriptor(self.host, self.port,
+                                                  timeout)
+        except Exception as e:
+            msg = 'Failed to instantiate master controller.\nHost: ' \
+                  '{}\nPort: {}\n{}'.format(host, port, e)
+            raise Exception(msg)
+
+        if not self.icepap_system:
+            msg = 'IcePAP system {} has no active drivers! ' \
+                  'Aborting.'.format(host)
+            raise Exception(msg)
+
+        self.sig_list = self.icepap_system.get_getters()
+        self.sig_getters = self.icepap_system.get_sig_getters()
+
+        self.ticker = QtCore.QTimer()
+        self.ticker.timeout.connect(self._tick)
+        self.ticker.start(self.settings.sample_rate)
+
+
+    @staticmethod
+    def get_current_time():
+        """
+        Retrieves the current time.
+
+        Return: Current time as seconds (with fractions) from 1970.
+        """
+        return time.time()
+
+    def subscribe(self, icepap_addr, signal_name):
+        """
+        Creates a new subscription for signal values.
+
+        icepap_addr - IcePAP driver number.
+        signal_name - Signal name.
+        Return - A positive integer id used when unsubscribing.
+        """
+        for ch in list(self.channels_subscribed.values()):
+            if ch.equals(icepap_addr, signal_name):
+                msg = 'Channel already exists.\nAddr: ' \
+                      '{}\nSignal: {}'.format(icepap_addr, signal_name)
+                raise Exception(msg)
+        channel = Channel(icepap_addr, signal_name)
+        sn = str(signal_name)
+
+        self.icepap_system.subscription_checks(icepap_addr, signal_name, channel)
+        '''
+        ###
+        cond_1 = sn.endswith('Tgtenc')
+        cond_2 = sn.endswith('Shftenc')
+        cond_3 = sn == 'DifAxMeasure'
+        if cond_1 or cond_2 or cond_3:
+            try:
+                cfg = self.icepap_system[icepap_addr].get_cfg()
+            except RuntimeError as e:
+                msg = 'Failed to retrieve configuration parameters ' \
+                      'for driver {}\n{}.'.format(icepap_addr, e)
+                raise Exception(msg)
+            if (cond_1 and cfg['TGTENC'].upper() == 'NONE') or \
+                    (cond_2 and cfg['SHFTENC'].upper() == 'NONE'):
+                msg = 'Signal {} is not mapped/valid.'.format(sn)
+                raise Exception(msg)
+            if cond_3:
+                channel.set_measure_resolution(cfg)
+        ###
+        '''
+        self.channel_id += 1
+        self.channels_subscribed[self.channel_id] = channel
+        return self.channel_id
+
+    def get_available_drivers(self):
+        return self.icepap_system.get_available_drivers()
+
+    def get_available_signals(self):
+        return self.icepap_system.get_available_signals()
+    
+    def start(self, subscription_id):
+        """
+        Starts collecting data for a subscription.
+
+        subscription_id - The given subscription id.
+        """
+        if subscription_id in list(self.channels_subscribed.keys()) and \
+                subscription_id not in list(self.channels.keys()):
+            self.channels[subscription_id] = \
+                self.channels_subscribed[subscription_id]
+
+    def unsubscribe(self, subscription_id):
+        """
+        Cancels a subscription.
+
+        subscription_id - The given subscription id.
+        """
+        if subscription_id in list(self.channels_subscribed.keys()):
+            del self.channels[subscription_id]
+            del self.channels_subscribed[subscription_id]
+
+    def _tick(self):
+        for subscription_id, channel in self.channels.items():
+            self.current_channel = subscription_id
+            try:
+                addr = channel.icepap_address
+                val = self.sig_getters[channel.sig_name](addr)
+            except RuntimeError as e:
+                msg = 'Failed to collect data for signal ' \
+                      '{}\n{}'.format(channel.sig_name, e)
+                print(msg)
+                continue
+            tv = (time.time(), val)
+            channel.collected_samples.append(tv)
+            if len(channel.collected_samples) >= self.settings.dump_rate:
+                self.cb(subscription_id, channel.collected_samples)
+                channel.collected_samples = []
+        self.ticker.start(self.settings.sample_rate)

--- a/icepaposc/collector.py
+++ b/icepaposc/collector.py
@@ -61,6 +61,7 @@ class Collector:
              ('EncAbsenc', self._getter_enc_absenc),
              ('EncTgtenc', self._getter_enc_tgtenc),
              ('EncInpos', self._getter_enc_inpos),
+             ('EncMeasure', self._getter_enc_measure),
              ('StatReady', self._getter_stat_ready),
              ('StatMoving', self._getter_stat_moving),
              ('StatSettling', self._getter_stat_settling),
@@ -258,14 +259,13 @@ class Collector:
         return x
 
     def _getter_pos_measure(self, addr):
-        x = self.icepap_system.get_fpos(self.icepap_system[addr].addr,
+        x = self.icepap_system.get_pos(self.icepap_system[addr].addr,
                                         'MEASURE')[0]
         x = x * self.poscorr_a + self.poscorr_b
         return x
 
     def _getter_dif_ax_measure(self, addr):
-        pos_measure = self._getter_pos_measure(addr) / \
-                      self.channels[self.current_channel].measure_resolution
+        pos_measure = self._getter_pos_measure(addr)
         x = self._getter_pos_axis(addr) - pos_measure
         x = x * self.poscorr_a
         return x
@@ -307,6 +307,12 @@ class Collector:
 
     def _getter_enc_inpos(self, addr):
         x = self.icepap_system[addr].enc_inpos
+        x = x * self.enccorr_a + self.enccorr_b
+        return x
+
+    def _getter_enc_measure(self, addr):
+        x = self.icepap_system.get_fpos(self.icepap_system[addr].addr,
+                                        'MEASURE')[0]
         x = x * self.enccorr_a + self.enccorr_b
         return x
 

--- a/icepaposc/curve_item.py
+++ b/icepaposc/curve_item.py
@@ -47,6 +47,8 @@ class CurveItem:
         self.val_cross = 0
         self.val_local_min = 0
         self.val_local_max = 0
+        self.last_idx_min = 0
+        self.last_idx_max = 0
         self.color = linecolor
         self.pen = {'color': linecolor,
                     'width': 1,
@@ -97,10 +99,10 @@ class CurveItem:
             if corr_factors != None and corr_factors != [] :
                 self.corr_factors = corr_factors
                 self.update_array_val_corr()
-            idx_min = self.get_time_index(time_min)
-            idx_max = self.get_time_index(time_max)
-            self.curve.setData(x=self.array_time[idx_min:idx_max],
-                               y=self.array_val_corr[idx_min:idx_max])
+            self.last_idx_min = self.get_time_index(time_min)
+            self.last_idx_max = self.get_time_index(time_max)
+            self.curve.setData(x=self.array_time[self.last_idx_min:self.last_idx_max],
+                               y=self.array_val_corr[self.last_idx_min:self.last_idx_max])
                                
     def update_array_val_corr(self):
         if self.signal_type == 1:
@@ -167,8 +169,6 @@ class CurveItem:
                 self.array_val.append(v)
                 vcorr = self.calculate_val_corr(v)
                 self.array_val_corr.append(vcorr)
-                #print(self.array_val_corr[-1])
-                #print(len(self.array_val_corr))
                 if vcorr > self.val_max:
                     self.val_max = v
                 elif vcorr < self.val_min:

--- a/icepaposc/manual_test/test_manual_window_main.py
+++ b/icepaposc/manual_test/test_manual_window_main.py
@@ -1,0 +1,57 @@
+import numpy
+import pytest
+import sys
+from icepaposc.window_main import WindowMain
+from PyQt5 import QtWidgets, Qt, QtCore, uic, QtGui
+from PyQt5.QtWidgets import QFileDialog, QShortcut, QApplication
+
+
+def test_main():
+    # args = get_parser().parse_args()
+    # print(args)
+
+    app = QApplication(sys.argv)
+    # win = WindowMain(args.host, args.port, args.timeout, args.sig,
+    #                 args.axis, args.sigset, args.corr, args.yrange)
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, [],
+                         1, "", "", "")
+    win.show()
+    # sys.exit(app.exec_())
+    app.exec_()
+
+    sig_list = [
+        '1:PosAxis:1',
+        '1:PosAbsenc:2',
+        '1:PosInpos:3',
+        '1:PosEncin:4',
+    ]
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_list,
+                     1, "", "", "")
+    win.show()
+    app.exec_()
+
+    axis_aux = 2
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_list,
+                     axis_aux, "", "", "")
+    win.show()
+    app.exec_()
+
+    sigset_file = "./test/SignalSet.lst"
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, "",
+                     2, sigset_file, "", "")
+    win.show()
+    app.exec_()
+
+    sigset_file = "./test/SignalSet.lst"
+    corr_factors_test = [2, 1000, 3, 10000]
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_list,
+                     1, sigset_file, corr_factors_test, "")
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    print("python -i -m icepaosc.test_manual_window_main")
+    test_main()
+
+

--- a/icepaposc/tests/FIcePAPController.py
+++ b/icepaposc/tests/FIcePAPController.py
@@ -1,0 +1,685 @@
+from numpy import random
+import collections
+import weakref
+
+class FIcePAPController:
+    """
+    Fake IcePAP motor controller class.
+    Implememnts only needed functionality for icepaposc
+    """
+    ALL_AXES_VALID = set([r * 10 + i for r in range(16) for i in range(1, 9)])
+
+    def __init__(self, host, port=5000, timeout=3, auto_axes=False, **kwargs):
+        print("FIC __init__")
+        log_name = '{0}.IcePAPController'.format(__name__)
+        # self.log = logging.getLogger(log_name)
+
+        #self._comm = IcePAPCommunication(host, port, timeout)
+
+        self._aliases = {}
+        self._axes = {}
+        self._host = host
+        self._port = port
+
+        if auto_axes:
+            for axis in self.find_axes(only_alive=True):
+                #self._axes[axis] = IcePAPAxis(self, axis)
+                # print("FIC __init__", axis)
+                self._axes[axis] = FIcePAPAxis(self, axis)
+        # print("FIC __init__ ended")
+        # print(self._axes)
+
+    def __getitem__(self, item):
+        if isinstance(item, str):
+            item = self._get_axis_for_alias(item)
+        elif isinstance(item, collections.abc.Sequence):
+            return [self[i] for i in item]
+        if item not in self._axes:
+            if item not in self.ALL_AXES_VALID:
+                raise ValueError('Bad axis value.')
+            self._axes[item] = IcePAPAxis(self, item)
+        return self._axes[item]
+
+    def __iter__(self):
+        return self._axes.__iter__()
+
+    def __delitem__(self, key):
+        self._axes.pop(key)
+        aliases_to_remove = []
+        for alias, axis in self._aliases.items():
+            if key == axis:
+                aliases_to_remove.append(alias)
+        for alias in aliases_to_remove:
+            self._aliases.pop(alias)
+
+    def __repr__(self):
+        return '{}({}:{})'.format(type(self).__name__,
+                                  self.host, self.port)
+
+    def __str__(self):
+        msg = 'IcePAPController connected ' \
+              'to {}:{}'.format(self.host, self.port)
+        return msg
+
+# -----------------------------------------------------------------------------
+#                       Properties
+# -----------------------------------------------------------------------------
+    @property
+    def host(self):
+        return self._host
+
+    @property
+    def port(self):
+        return self._port
+    '''
+    @host.setter
+    def host(self, host):
+        self.host = host
+
+    @port.setter
+    def port(self, port):
+        self.port = port
+    '''
+    @property
+    def axes(self):
+        """
+        Get the axes numbers.
+
+        :return: [int]
+        """
+        axes = list(self._axes.keys())
+        axes.sort()
+        return axes 
+
+    def find_axes(self, only_alive=False):
+        # Take the list of racks present in the system
+        # IcePAP user manual pag. 137
+        # racks_present = int(self._comm.send_cmd('?sysstat')[0], 16)
+        # rack_mask = 1
+        axes = []
+        # print('FIC find_axes')
+        axes.append(1)
+        axes.append(2)
+        axes.append(3)
+        axes.append(4)
+        if only_alive:
+            pass
+        '''
+        for i in range(16):
+            if (racks_present & rack_mask << i) > 0:
+                # Take the motors presents for a rack.
+                cmd = '?sysstat {0}'.format(i)
+                drivers_mask = self._comm.send_cmd(cmd)
+                # TODO: Analyze if use the present or the alive mask
+                if only_alive:
+                    # Drivers alive
+                    drvs = int(drivers_mask[1], 16)
+                else:
+                    # Drivers present
+                    drvs = int(drivers_mask[0], 16)
+                drv_mask = 1
+                for j in range(8):
+                    if (drvs & drv_mask << j) > 0:
+                        axis_nr = i * 10 + j + 1
+                        axes.append(axis_nr)
+        '''
+        return axes
+
+class FIcePAPAxis:
+    """
+    The IcePAP axis class contains the common IcePAP ASCii API for any
+    IcePAP axis. The methods here implemented correspond to those
+    at the axis level.
+    """
+    def __init__(self, ctrl, axis_nr):
+        ref = weakref.ref(ctrl)
+        self._ctrl = ref()
+        self._axis_nr = axis_nr
+        # print("FIA __init__ end", axis_nr)
+
+        # if self._axis_nr != self.addr:
+        #     msg = 'Initialization error: axis_nr {0} != adr {1}'.format(
+        #         self._axis_nr, self.addr)
+        #     raise RuntimeError(msg)
+
+    def __repr__(self):
+        return '{}({})'.format(type(self).__name__, self._axis_nr)
+
+    def __str__(self):
+        return 'IcePAPAxis {} on {}'.format(self._axis_nr, self._ctrl)
+    
+    @property
+    def axis(self):
+        """
+        Get the axis number (IcePAP user manual pag. 49).
+        Local internal address (no communication with the IcePAP)
+
+        :return: int
+        """
+        return self._axis_nr
+
+    @property
+    def addr(self):
+        """
+        Get the axis number (IcePAP user manual pag. 49).
+
+        :return: int
+        """
+        # return int(self.send_cmd('?ADDR')[0])
+        return self._axis_nr 
+
+    @property
+    def active(self):
+        """
+        Get if the axis is active (IcePAP user manual pag. 47).
+
+        :return: bool
+        """
+        # ans = self.send_cmd('?ACTIVE')[0].upper()
+        # return ans == 'YES'
+        return True
+
+    @property
+    def mode(self):
+        """
+        Return the current mode of the axis: CONFIG, OPER, PROG, TEST, FAIL
+        (IcePAP user manual pag. 91).
+
+        :return: str
+        """
+        # return self.send_cmd('?MODE')[0]
+        return "OPER"
+
+    @property
+    def status(self):
+        """
+        Return axis status word 32-bits (IcePAP user manual pag. 128).
+
+        :return: int
+        """
+        # return int(self.send_cmd('?STATUS')[0], 16)
+        return 0
+
+    def get_cfg(self, parameter=''):
+        """
+        Get the current configuration for one or all parameters (IcePAP user
+        manual pag. 54).
+
+        :param parameter: str (optional)
+        :return: dict
+        """
+        cfg = collections.OrderedDict()
+        cfg['ANSTEP'] = 400
+        cfg['TGTENC'] = "AbsEnc"
+        cfg['SHFTENC'] = "NONE"
+        return cfg
+
+    @property
+    def pos(self):
+        """
+        Read the axis nominal position pointer (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        # return self.get_pos('AXIS')
+        return self._axis_nr + random.rand()
+
+    @property
+    def pos_measure(self):
+        """
+        Read the measure register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()
+        # return self.get_pos('MEASURE')
+
+    @property
+    def pos_shftenc(self):
+        """
+        Read the shftenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        # return self.get_pos('SHFTENC')
+        return self._axis_nr + random.rand()
+    
+
+    @property
+    def pos_tgtenc(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()
+        # return self.get_pos('TGTENC')
+
+    @property
+    def pos_encin(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()        
+
+    @property
+    def pos_absenc(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()        
+
+    @property
+    def pos_inpos(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()        
+
+    @property
+    def pos_motor(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()        
+
+    @property
+    def pos_ctrlenc(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()        
+
+    @property
+    def pos_motor(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()        
+
+    @property
+    def pos_measure(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()        
+
+    @property
+    def pos_measure(self):
+        """
+        Read the measure register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand()
+        # return self.get_pos('MEASURE')
+
+    @property
+    def pos_shftenc(self):
+        """
+        Read the shftenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        # return self.get_pos('SHFTENC')
+        return self._axis_nr + random.rand()
+    
+    @property
+    def enc_tgtenc(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand() + 100
+        # return self.get_pos('TGTENC')
+
+    @property
+    def enc_encin(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand() + 100        
+
+    @property
+    def enc_absenc(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand() + 100        
+
+    @property
+    def enc_inpos(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand() + 100        
+
+    @property
+    def enc_motor(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand() + 100        
+
+    @property
+    def enc_ctrlenc(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand() + 100        
+
+    @property
+    def enc_motor(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand() + 100        
+
+    @property
+    def enc_measure(self):
+        """
+        Read the tgtenc register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self._axis_nr + random.rand() + 100        
+
+    @property
+    def meas_vcc(self):
+        """
+        Measured value of the main power supply (IcePAP user manual pag. 89).
+
+        :return: float
+        """
+        return self._axis_nr + random.rand() + 300  
+
+    @property
+    def meas_vm(self):
+        """
+        Measured value of the motor voltage (IcePAP user manual pag. 89).
+
+        :return: float
+        """
+        return self._axis_nr + random.rand() + 100  
+
+    @property
+    def meas_i(self):
+        """
+        Measured value of the motor current (IcePAP user manual pag. 89).
+
+        :return: float
+        """
+        return self._axis_nr + random.rand() + 100  
+
+    @property
+    def meas_ia(self):
+        """
+        Measured value of the phase a current (IcePAP user manual pag. 89).
+
+        :return: float
+        """
+        return self._axis_nr + random.rand() + 100  
+
+    @property
+    def meas_ib(self):
+        """
+        Measured value of the phase b current (IcePAP user manual pag. 89).
+
+        :return: float
+        """
+        return self._axis_nr + random.rand() + 100  
+
+    @property
+    def state_present(self):
+        """
+        Check if the present flag is active.
+
+        :return: bool
+        """
+        return True
+
+    @property
+    def state_alive(self):
+        """
+        Check if the alive flag is active.
+
+        :return: bool
+        """
+        return True
+
+    @property
+    def state_mode_code(self):
+        """
+        Return the current mode.
+
+        :return: int
+        """
+        return 0
+
+    @property
+    def state_disabled(self):
+        """
+        Check if the disable flag is active.
+
+        :return: bool
+        """
+        return True
+
+    @property
+    def state_disable_code(self):
+        """
+        Return the disable code.
+
+        :return: int
+        """
+        return 0
+
+    @property
+    def state_indexer_code(self):
+        """
+        Return the indexer code.
+
+        :return: int
+        """
+        return 0
+
+    @property
+    def state_moving(self):
+        """
+        Check if the moving flag is active.
+
+        :return: bool
+        """
+        return True
+
+    @property
+    def state_ready(self):
+        """
+        Check if the ready flag is active.
+
+        :return: bool
+        """
+        return True
+
+    @property
+    def state_settling(self):
+        """
+        Check if the settling flag is active.
+
+        :return: bool
+        """
+        return False
+
+    @property
+    def state_outofwin(self):
+        """
+        Check if the outofwin flag is active.
+
+        :return: bool
+        """
+        return False
+
+    @property
+    def state_warning(self):
+        """
+        Check if the warning flag is active.
+
+        :return: bool
+        """
+        return True
+
+    @property
+    def state_stop_code(self):
+        """
+        Return the stop code.
+
+        :return: int
+        """
+        return 0
+
+    @property
+    def state_limit_positive(self):
+        """
+        Check if the flag limit_positive is active.
+
+        :return: bool
+        """
+        return False
+
+    @property
+    def state_limit_negative(self):
+        """
+        Check if the flag limit_negative is active.
+
+        :return: bool
+        """
+        return False
+
+    @property
+    def state_inhome(self):
+        """
+        Chekc if the home flag is active.
+
+        :return: bool
+        """
+        return False
+
+    @property
+    def state_5vpower(self):
+        """
+        Check if the auxiliary power is On.
+
+        :return: bool
+        """
+        return False
+
+    @property
+    def state_verserr(self):
+        """
+        Check if the vererr flag is active.
+
+        :return: bool
+        """
+        return False
+
+    @property
+    def state_poweron(self):
+        """
+        Check if the flag poweron is active.
+
+        :return: bool
+        """
+        return False
+
+    @property
+    def state_info_code(self):
+        """
+        Return the info code.
+
+        :return: int
+        """
+        return 0
+    
+    @property
+    def velocity_current(self):
+        """
+        Read the default velocity (see get_velocity method).
+
+        :return: float
+        """
+        return 1000.0 + random.rand()
+
+    def get_velocity(self, vtype):
+        """
+        Read the default velocity (see get_velocity method).
+
+        :return: float
+        """
+        if vtype:
+            pass
+        return 1000.0 + random.rand()
+    
+    
+
+'''
+            [('PosAxis', self._getter_pos_axis),
+             ('PosTgtenc', self._getter_pos_tgtenc),
+             ('PosShftenc', self._getter_pos_shftenc),
+             ('PosEncin', self._getter_pos_encin),
+             ('PosAbsenc', self._getter_pos_absenc),
+             ('PosInpos', self._getter_pos_inpos),
+             ('PosMotor', self._getter_pos_motor),
+             ('PosCtrlenc', self._getter_pos_ctrlenc),
+             ('PosMeasure', self._getter_pos_measure),
+             ('DifAxMeasure', self._getter_dif_ax_measure),
+             ('DifAxMotor', self._getter_dif_ax_motor),
+             ('DifAxTgtenc', self._getter_dif_ax_tgtenc),
+             ('DifAxShftenc', self._getter_dif_ax_shftenc),
+             ('DifAxCtrlenc', self._getter_dif_ax_ctrlenc),
+             ('EncEncin', self._getter_enc_encin),
+             ('EncAbsenc', self._getter_enc_absenc),
+             ('EncTgtenc', self._getter_enc_tgtenc),
+             ('EncInpos', self._getter_enc_inpos),
+             ('StatReady', self._getter_stat_ready),
+             ('StatMoving', self._getter_stat_moving),
+             ('StatSettling', self._getter_stat_settling),
+             ('StatOutofwin', self._getter_stat_outofwin),
+             ('StatStopcode', self._getter_stat_stopcode),
+             ('StatWarning', self._getter_stat_warning),
+             ('StatLim+', self._getter_stat_limit_positive),
+             ('StatLim-', self._getter_stat_limit_negative),
+             ('StatHome', self._getter_stat_home),
+             ('MeasI', self._getter_meas_i),
+             ('MeasIa', self._getter_meas_ia),
+             ('MeasIb', self._getter_meas_ib),
+             ('MeasVm', self._getter_meas_vm),
+             ('VelCurrent', self._getter_vel_current),
+             ('VelMotor', self._getter_vel_motor)]
+'''

--- a/icepaposc/tests/SignalSet.lst
+++ b/icepaposc/tests/SignalSet.lst
@@ -1,0 +1,6 @@
+PosAxis 1 #ff0000 0 
+DifAxTgtenc 3 #00ff00 0 
+DifAxMotor 3 #007fff 0 
+VelCurrent 5 #00ffff 0 
+EncTgtenc 2 #008000 0 
+StatMoving 6 #ff0000 0 

--- a/icepaposc/tests/test_signal_lists.py
+++ b/icepaposc/tests/test_signal_lists.py
@@ -1,0 +1,67 @@
+import numpy
+import pytest
+import sys
+from icepaposc.window_main import WindowMain
+from PyQt5 import QtWidgets, Qt, QtCore, uic, QtGui
+from PyQt5.QtWidgets import QFileDialog, QShortcut, QApplication
+
+@pytest.fixture
+def app(qtbot):
+    signal_list = [
+                    '1:PosAxis:1',
+                    '2:EncTgtenc:2',
+                    '3:DifAxTgtenc:3',
+    ]
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, signal_list,
+                     2, "", "", "")
+    qtbot.addWidget(win)
+    return win
+
+def test_signal_list(app):
+    assert len(app.curve_items) == 3
+    assert len(app.collector.channels_subscribed.keys()) == 3
+    assert app.ui.lvActiveSig.count() == 3
+    
+
+'''
+
+def test_main():
+    # args = get_parser().parse_args()
+    # print(args)
+
+    app = QApplication(sys.argv)
+    # win = WindowMain(args.host, args.port, args.timeout, args.sig,
+    #                 args.axis, args.sigset, args.corr, args.yrange)
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, [],
+    ----                 1, "", "", "")
+    sig_set = [
+        '1:PosAxis:1',
+        '1:PosAbsenc:1',
+        '1:PosInpos:1',
+        '1:PosEncin:1',
+    ]
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_set,
+                     1, "", "", "")
+    axis_aux = 2
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_set,
+                     axis_aux, "", "", "")
+    sigset_file = "sigset.lst"
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_set,
+                     1, sigset_file, "", "")
+    sigset_file = "sigset.lst"
+    corr_factors_test = [2, 1000, 3 10000]
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_set,
+                     1, sigset_file, corr_factors_test, "")
+    #---
+    win.show()
+    sys.exit(app.exec_())
+'''
+
+
+if __name__ == "__main__":
+    print("python -i -m icepaosc.test_window_main")
+    # get icepap_client (python 3.11) add pytest and pytest-qt with conda or pip
+    # pytest ./test_window_main.py --log-level=DEBUG --verbosity=10
+    test_main()
+
+

--- a/icepaposc/tests/test_signal_sets.py
+++ b/icepaposc/tests/test_signal_sets.py
@@ -1,0 +1,60 @@
+
+import numpy
+import pytest
+import sys
+from icepaposc.window_main import WindowMain
+from PyQt5 import QtWidgets, Qt, QtCore, uic, QtGui
+from PyQt5.QtWidgets import QFileDialog, QShortcut, QApplication
+
+@pytest.fixture
+def app(qtbot):
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, [],
+                     2, "./tests/SignalSet.lst", "", "")
+    qtbot.addWidget(win)
+    return win
+
+def test_signal_set(app):
+    assert len(app.curve_items) == 6
+
+'''
+
+def test_main():
+    # args = get_parser().parse_args()
+    # print(args)
+
+    app = QApplication(sys.argv)
+    # win = WindowMain(args.host, args.port, args.timeout, args.sig,
+    #                 args.axis, args.sigset, args.corr, args.yrange)
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, [],
+    ----                 1, "", "", "")
+    sig_set = [
+        '1:PosAxis:1',
+        '1:PosAbsenc:1',
+        '1:PosInpos:1',
+        '1:PosEncin:1',
+    ]
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_set,
+                     1, "", "", "")
+    axis_aux = 2
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_set,
+                     axis_aux, "", "", "")
+    sigset_file = "sigset.lst"
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_set,
+                     1, sigset_file, "", "")
+    sigset_file = "sigset.lst"
+    corr_factors_test = [2, 1000, 3 10000]
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, sig_set,
+                     1, sigset_file, corr_factors_test, "")
+    #---
+    win.show()
+    sys.exit(app.exec_())
+'''
+
+
+if __name__ == "__main__":
+    print("python -i -m icepaosc.test_window_main")
+    # get icepap_client (python 3.11) add pytest and pytest-qt with conda or pip
+    # pytest ./test_window_main.py --log-level=DEBUG --verbosity=10
+    test_main()
+
+

--- a/icepaposc/tests/test_window_main.py
+++ b/icepaposc/tests/test_window_main.py
@@ -1,0 +1,181 @@
+import numpy
+import pytest
+import sys
+from icepaposc.window_main import WindowMain
+from PyQt5 import QtWidgets, Qt, QtCore, uic, QtGui
+from PyQt5.QtWidgets import QFileDialog, QShortcut, QApplication
+
+@pytest.fixture
+def app(qtbot):
+    win = WindowMain("w-kitslab-icepap-21", 5000, 3, [],
+                      1, "", "", "")
+    qtbot.addWidget(win)
+    return win
+
+def test_yscaled(app, qtbot):
+    assert app.host == "w-kitslab-icepap-21"
+    # press cloop button, wait 3s, check data in
+    app.ui.btnCLoop.click()
+    # Correct number of curves
+    assert len(app.curve_items) == 9
+    # Acquisition running
+    assert not app._paused
+    # x axis length is 30s
+    vr = app.view_boxes[0].viewRange()
+    assert vr[0][1] - vr[0][0] == 30
+    # some data in
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 30)
+    yscale_mode_after_cloopbtn_tests(qtbot, app)
+    assert app.last_now <= app.view_boxes[0].viewRange()[0][1]
+    assert app.last_now >= app.view_boxes[0].viewRange()[0][0]
+    #press cloop again (restarting acq) and test ytiled mode
+    app.ui.btnCLoop.click()
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 60)
+    assert app.view_boxes[0].state['autoRange'][1] == True
+    last_yranges = []
+    for i in range(0,5):
+        last_yranges.append(app.view_boxes[i].viewRange()[1])
+    app.ui.btnResetY.click()
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 90)
+    ytiled_mode_tests(qtbot, app, last_yranges)
+
+
+def yscale_mode_after_cloopbtn_tests(qtbot, app):
+    assert app.ytiled_viewbox_next
+    # check all yaxes except last one have autorange on
+    assert app.view_boxes[0].state['autoRange'][1] == True
+    assert app.view_boxes[1].state['autoRange'][1] == True
+    assert app.view_boxes[2].state['autoRange'][1] == True
+    assert app.view_boxes[3].state['autoRange'][1] == True
+    assert app.view_boxes[4].state['autoRange'][1] == True
+    # assert app.view_boxes[5].state['autoRange'][1] == True
+    # check xaxis is panning (scope mode) 
+    assert app.view_boxes[0].state['autoRange'][0] == False
+    assert app.ui.btnResetX.text() == 'tSCALE'
+    assert app.ui.btnResetY.text() == 'ySPLIT'
+
+def ytiled_mode_tests(qtbot, app, last_yranges):
+    assert not app._paused
+    assert not app.ytiled_viewbox_next
+    assert app.ui.btnResetY.text() == 'ySCALE'
+    # some data in
+    # check all yaxes except last one have autorange off
+    assert app.view_boxes[0].state['autoRange'][1] == False
+    assert app.view_boxes[1].state['autoRange'][1] == False
+    assert app.view_boxes[2].state['autoRange'][1] == False
+    assert app.view_boxes[3].state['autoRange'][1] == False
+    assert app.view_boxes[4].state['autoRange'][1] == False
+    # assert app.view_boxes[5].state['autoRange'][1] == True
+    # check xaxis is panning (scope mode) 
+    assert app.view_boxes[0].state['autoRange'][0] == False
+    assert app.ui.btnResetX.text() == 'tSCALE'
+    assert app.last_now <= app.view_boxes[0].viewRange()[0][1]
+    assert app.last_now >= app.view_boxes[0].viewRange()[0][0]
+    # check in ytiled mode
+    assert app.ytiled_viewbox_next == False
+    assert app.last_tiled_y_ranges[0] != [0,0]
+    assert app.last_tiled_y_ranges[0] == app.view_boxes[0].viewRange()[1]
+    assert app.last_tiled_y_ranges[1] != [0,0]
+    assert app.last_tiled_y_ranges[1] == app.view_boxes[1].viewRange()[1]
+    assert app.last_tiled_y_ranges[2] != [0,0]
+    assert app.last_tiled_y_ranges[2] == app.view_boxes[2].viewRange()[1]
+    assert app.last_tiled_y_ranges[3] != [0,0]
+    assert app.last_tiled_y_ranges[3] == app.view_boxes[3].viewRange()[1]
+    assert app.last_tiled_y_ranges[4] != [0,0]
+    assert app.last_tiled_y_ranges[4] == app.view_boxes[4].viewRange()[1]
+    vertical_slots = 6
+    fill_factor = 2
+    for i in range(0, 5):
+        [amin, amax] = last_yranges[i]
+        old_center = amin + (amax-amin) / 2
+        old_range = amax - amin
+        slots_above = 1 + 2*i
+        slots_below = 2 * vertical_slots - i*2 -1
+        new_amax = old_center + slots_above * old_range / fill_factor
+        new_amin = old_center - slots_below * old_range / fill_factor
+        assert app.view_boxes[i].viewRange()[1] == [new_amin, new_amax]
+
+def update_corrector_factors_ui(app, cf):
+    app.ui.txt_poscorr_a.setText(str(cf[0]))
+    app.ui.txt_poscorr_b.setText(str(cf[1]))
+    app.ui.txt_enccorr_a.setText(str(cf[2]))
+    app.ui.txt_enccorr_b.setText(str(cf[3]))
+
+'''
+For some reason the change to corrected does not work with autorangey
+in pytest, so correction factors cant be tested against yarange and ytiled
+modes. It does work in real
+
+def test_corr_ar(app, qtbot):
+    #Now check ytiled mode AFTER a toggle to units
+    assert app.host == "w-kitslab-icepap-21"
+    app.ui.btnCLoop.click()
+    assert not app._paused
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 30)
+    ui_corr_factors = [2,100,3,1000]
+    print('ui corr updated')
+    update_corrector_factors_ui(app, ui_corr_factors)
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 40)
+    last_yranges = []
+    for i in range(0,5):
+        last_yranges.append(app.view_boxes[i].viewRange()[1])
+    yscale_mode_after_cloopbtn_tests(qtbot, app)
+    # app.ui.btnResetY.click()
+    #print('toggle ar into tiled')
+    #app._toggle_y_autorange()
+    #qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 50)
+    #qtbot.waitUntil(lambda: not app.ytiled_viewbox_next)
+    # assert len(app.curve_items[0].array_val) == 30
+    #ytiled_mode_tests(qtbot, app, last_yranges)
+    #print('tiled ok')
+    # some data in after tiled mode
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 50)
+    # app.curve_items[0].array_val[-1] = 50
+    # check applied corrector factors are still default
+    # assert app.corr_factors == [1,0,1,0]
+    assert app.corr_factors == ui_corr_factors
+    # now  toggle units and check everything is ok
+    last_yranges = []
+    for i in range(0,5):
+        last_yranges.append(app.view_boxes[i].viewRange()[1])
+    # update_corrector_factors_ui(app, [2, 100, 3, 1000])
+    last_coll = app.last_now
+    print('toggle corr')
+    app._toggle_corr_factors()
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 70)
+    print('toggle corr')
+    app._toggle_corr_factors()
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 80)
+    print('toggle corr')
+    app._toggle_corr_factors()
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 90)
+    # app._toggle_corr_factors()
+    assert app.corr_factors == app.corr_factors_ui
+    # wait until the forced yautorange happens
+'''
+
+def test_tiled(app, qtbot):
+    #Now check ytiled mode AFTER a toggle to units
+    assert app.host == "w-kitslab-icepap-21"
+    app.ui.btnCLoop.click()
+    assert not app._paused
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 30)
+    ui_corr_factors = [1,0,1,0]
+    update_corrector_factors_ui(app, ui_corr_factors)
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 40)
+    last_yranges = []
+    for i in range(0,5):
+        last_yranges.append(app.view_boxes[i].viewRange()[1])
+    # Change from yautorange to ytiled mode and test
+    yscale_mode_after_cloopbtn_tests(qtbot, app)
+    app._toggle_y_autorange()
+    qtbot.waitUntil(lambda: not app.ytiled_viewbox_next)
+    ytiled_mode_tests(qtbot, app, last_yranges)
+    # some data in after tiled mode
+    qtbot.waitUntil(lambda: len(app.curve_items[0].array_val) == 50)
+
+if __name__ == "__main__":
+    # print("python -i -m icepaosc.test_window_main")
+    test_header()
+
+

--- a/icepaposc/ui/window_main.ui
+++ b/icepaposc/ui/window_main.ui
@@ -1509,6 +1509,11 @@
           </item>
           <item>
            <property name="text">
+            <string>Y6</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
             <string>X</string>
            </property>
           </item>

--- a/icepaposc/window_main.py
+++ b/icepaposc/window_main.py
@@ -591,7 +591,7 @@ class WindowMain(QtWidgets.QMainWindow):
         txtlocalmax = ''
         text_size = 8
         float_decimals = 9
-        span_html = "{}{:." + str(float_decimals) + "f}</span>"
+        span_html = "{}{}</span>"
         for ci in self.curve_items:
             tmp = "<span style='font-size: {}pt; overflow: hidden; color: {};'>|"
             tmp = tmp.format(text_size, ci.color.name())

--- a/icepaposc/window_main.py
+++ b/icepaposc/window_main.py
@@ -1438,7 +1438,7 @@ class WindowMain(QtWidgets.QMainWindow):
                 used_yaxes.append(i)
         print(used_yaxes)
         vertical_slots = len(used_yaxes)
-        fill_factor = 0.5
+        fill_factor = 1.9
         yslot = 0
         #Dont change last view box (status signals)
         for yaxis in range(0, len(self.view_boxes) - 1):

--- a/icepaposc/window_main.py
+++ b/icepaposc/window_main.py
@@ -39,7 +39,7 @@ class WindowMain(QtWidgets.QMainWindow):
     """A dialog for plotting IcePAP signals."""
 
     def __init__(self, host, port, timeout, siglist,
-                 selected_driver=None, sigset=None, corr=None, yrange=None):
+                 selected_driver=None, sigset=None, corr=None, yrange=None, dump_rate=1, sample_rate=50):
         """
         Initializes an instance of class WindowMain.
 
@@ -63,6 +63,10 @@ class WindowMain(QtWidgets.QMainWindow):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
         self.setWindowTitle('Oscilloscope | {}'.format(host))
         self.settings = Settings()
+        if dump_rate != 1:
+            self.settings.dump_rate = dump_rate
+        if sample_rate != 50:
+            self.settings.sample_rate = sample_rate
 
         # Corrector factors for POS and ENC
         # Take cmd line, fill ui

--- a/icepaposc/window_main.py
+++ b/icepaposc/window_main.py
@@ -518,6 +518,8 @@ class WindowMain(QtWidgets.QMainWindow):
 
     def _remove_empty_y_axis(self, y_axis):
         i = y_axis - 1
+        if i in self.skip_autorange:
+            self.skip_autorange.remove(i)
         if i is not None and i > 1:
             if self.y_axis_empty(y_axis):
                 try:

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,9 @@ __version = '0.10.2'
 # python setup.py bdist_wininst
 
 
-long_description = """ Python application to monitor and tune IcePAP based 
-systems. """
+long_description = """
+Python application to monitor and tune IcePAP based systems. 
+"""
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 # The version is updated automatically with bumpversion
 # Do not update manually
-__version = '0.10.3'
+__version = '0.10.4'
 
 # windows installer:
 # python setup.py bdist_wininst

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 # The version is updated automatically with bumpversion
 # Do not update manually
-__version = '0.10.0'
+__version = '0.10.1'
 
 # windows installer:
 # python setup.py bdist_wininst

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 # The version is updated automatically with bumpversion
 # Do not update manually
-__version = '0.10.1'
+__version = '0.10.2'
 
 # windows installer:
 # python setup.py bdist_wininst

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 # The version is updated automatically with bumpversion
 # Do not update manually
-__version = '0.10.2'
+__version = '0.10.3'
 
 # windows installer:
 # python setup.py bdist_wininst


### PR DESCRIPTION
Future version 0.10.5

Bug fixes:
- Y axes autorange/tiled mode was buggy last commit.
- A number of other small bugs
Additions:
- When using .lst files for command line added signal sets, the old force_autorange last parameter in each signal/file line becomes now skip_autorange (more useful)
- When using y axes in tiled mode (old split window), changing to units autoranges
- Added some pytest files

If you were using .lst files, you probably want to edit the last number of each line and change it to 0 (NOT skip_autorange). Before a 1 there was meaning force_autorange